### PR TITLE
fix: fix data retrieval in fetchPodcasts thunk and update AppState model

### DIFF
--- a/src/store/actions/models/ModelStorePodcast.ts
+++ b/src/store/actions/models/ModelStorePodcast.ts
@@ -78,7 +78,7 @@
 
   export  interface AppState {
       podcasts: {
-        data: PodcastItemData[];
+        podcasts: PodcastItemData[];
         lastFetchTimestamp: number;
       };
     }

--- a/src/store/actions/podcastsActions.tsx
+++ b/src/store/actions/podcastsActions.tsx
@@ -18,7 +18,7 @@ export const fetchPodcasts = createAsyncThunk(
 		const day = 24 * 60 * 60 * 1000;
 
 		if (dataNow - lastFetchTimestamp < day) {
-			return state.podcasts.data;
+			return state.podcasts.podcasts;
 		}
 
 		try {


### PR DESCRIPTION
Updated the fetchPodcasts thunk to retrieve the correct podcast data from the state. Changed the data property to podcasts in the AppState model to align with the updated data structure